### PR TITLE
Add support for /review flag to trigger AI re-evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This action supports the following GitHub workflow events:
   - Used to analyze and enhance new or updated issues.
 - **issue_comment**
   - Triggered on issue comment events such as `created`.
-  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`, `/review`).
+  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`)
 
 Example configuration in your workflow:
 
@@ -141,6 +141,16 @@ on:
 ```
 
 See the [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) for more details on workflow events and triggers.
+
+## Supported Commands
+
+### 🚀 Available Commands
+
+| Command     | Functionality                                                | Notes                                                                 |
+|-------------|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| `/apply`    | Applies the latest AI-enhanced title, body, and labels to the GitHub issue. | Must be used as a GitHub comment on an issue with a valid enhancement suggestion. |
+| `/review`   | Triggers a new AI review of the issue and posts the updated evaluation as a comment. | Does not update the issue directly; useful for iterative refinement or rechecks. |
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This action supports the following GitHub workflow events:
   - Used to analyze and enhance new or updated issues.
 - **issue_comment**
   - Triggered on issue comment events such as `created`.
-  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`).
+  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`, `/review`).
 
 Example configuration in your workflow:
 

--- a/src/comment_commands.py
+++ b/src/comment_commands.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class CommentCommand(str, Enum):
+    APPLY = "/apply"
+    REVIEW = "/review"

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import asyncio
 # Third-party imports
 from github.Issue import Issue
 from semantic_kernel import Kernel
+from comment_commands import CommentCommand
 
 # Local imports
 from github_utils import (
@@ -21,8 +22,6 @@ from prompts import build_user_story_eval_prompt
 from utils import get_env_var
 from response_models import UserStoryEvalResponse
 
-APPLY_COMMENT = "/apply"
-REVIEW_COMMENT = "/review"
 
 def handle_github_issues_event(issue: Issue, kernel: Kernel) -> None:
     """
@@ -56,7 +55,7 @@ def handle_github_comment_event(issue: Issue, issue_comment_id: int) -> None:
     comment = get_github_comment(issue, issue_comment_id)
     comment_body = comment.body.strip().lower()
 
-    if APPLY_COMMENT in comment_body:
+    if CommentCommand.APPLY in comment_body:
         ai_enhanced_comment = get_ai_enhanced_comment(issue)
         if ai_enhanced_comment is None:
             return
@@ -78,7 +77,7 @@ def handle_github_comment_event(issue: Issue, issue_comment_id: int) -> None:
 
         create_github_issue_comment(issue, confirmation_comment)
 
-    elif REVIEW_COMMENT in comment_body:
+    elif CommentCommand.REVIEW in comment_body:
         print(f"Triggering manual review for issue {issue.number}...")
 
         # Initialize the kernel

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,8 @@ from prompts import build_user_story_eval_prompt
 from utils import get_env_var
 from response_models import UserStoryEvalResponse
 
-COMMENT_LOOKUP = "/apply"
+APPLY_COMMENT = "/apply"
+REVIEW_COMMENT = "/review"
 
 def handle_github_issues_event(issue: Issue, kernel: Kernel) -> None:
     """
@@ -46,43 +47,54 @@ def handle_github_issues_event(issue: Issue, kernel: Kernel) -> None:
 
 def handle_github_comment_event(issue: Issue, issue_comment_id: int) -> None:
     """
-    Apply AI-suggested enhancements to a GitHub issue if requested in a comment.
+    Apply AI-suggested enhancements to a GitHub issue, or trigger a re-review if requested in a comment.
 
     Args:
         issue (Issue): The GitHub issue to update.
-        issue_comment_id (int): The ID of the comment triggering the enhancement.
+        issue_comment_id (int): The ID of the comment triggering the enhancement or review.
     """
     comment = get_github_comment(issue, issue_comment_id)
+    comment_body = comment.body.strip().lower()
 
-    if COMMENT_LOOKUP not in comment.body:
+    if APPLY_COMMENT in comment_body:
+        ai_enhanced_comment = get_ai_enhanced_comment(issue)
+        if ai_enhanced_comment is None:
+            return
+
+        user_story_eval = UserStoryEvalResponse.from_markdown(ai_enhanced_comment)
+
+        update_github_issue(
+            issue,
+            title=user_story_eval.refactored.title,
+            body=user_story_eval.refactored.body_markdown(),
+            labels=user_story_eval.labels,
+        )
+
+        quoted_body = "\n".join([f"> {line}" for line in user_story_eval.to_markdown().strip().splitlines()])
+        confirmation_comment = (
+            f"✅ Applied enhancements based on the following comment:\n\n"
+            f"{quoted_body}"
+        )
+
+        create_github_issue_comment(issue, confirmation_comment)
+
+    elif REVIEW_COMMENT in comment_body:
+        print(f"Triggering manual review for issue {issue.number}...")
+
+        # Initialize the kernel
+        azure_openai_target_uri = get_env_var("INPUT_AZURE_OPENAI_TARGET_URI")
+        azure_openai_api_key = get_env_var("INPUT_AZURE_OPENAI_API_KEY")
+
+        kernel = initialize_kernel(
+            azure_openai_target_uri=azure_openai_target_uri,
+            azure_openai_api_key=azure_openai_api_key,
+        )
+
+        handle_github_issues_event(issue, kernel)
+
+    else:
         print(f"Comment {issue_comment_id} does not require processing.")
-        return
 
-    ai_enhanced_comment = get_ai_enhanced_comment(issue)
-
-    if ai_enhanced_comment is None:
-        return
-
-    user_story_eval = UserStoryEvalResponse.from_markdown(ai_enhanced_comment)
-
-    update_github_issue(
-        issue,
-        title=user_story_eval.refactored.title,
-        body=user_story_eval.refactored.body_markdown(),
-        labels=user_story_eval.labels,
-    )
-
-    quoted_body = "\n".join([f"> {line}" for line in user_story_eval.to_markdown().strip().splitlines()])
-
-    # Confirmation comment quoting the original enhancement comment
-    confirmation_comment = (
-        f"✅ Applied enhancements based on the following comment:\n\n"
-        f"{quoted_body}"
-    )
-
-    create_github_issue_comment(
-        issue, confirmation_comment
-    )
 
 
 def main() -> None:

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -241,6 +241,6 @@ class UserStoryEvalResponse:
         if self.refactored and (not self.ready_to_work and not self.base_story_not_clear):
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
-            lines.append('\n Reply with "/apply" to apply these updates, or "/review" to trigger another review of the story.\n')
+            lines.append('\n Reply with `/apply` to accept these changes, or `/review` to run another evaluation.\n')
 
         return "\n".join(lines)

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -241,6 +241,8 @@ class UserStoryEvalResponse:
         if self.refactored and (not self.ready_to_work and not self.base_story_not_clear):
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
-            lines.append('\n Reply with `/apply` to accept these changes, or `/review` to run another evaluation.\n')
+            lines.append("\n Reply `/apply` to apply these changes.\n")
+            
+        lines.append("\n Reply `/review` to run another evaluation.\n")
 
         return "\n".join(lines)

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -241,6 +241,6 @@ class UserStoryEvalResponse:
         if self.refactored and (not self.ready_to_work and not self.base_story_not_clear):
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
-            lines.append("\n Reply \"/apply\" to apply these updates.\n")
-            lines.append("\n Reply \"/review\" to re-review this issue.\n")
+            lines.append('\n Reply with "/apply" to apply these updates, or "/review" to trigger another review of the story.\n')
+
         return "\n".join(lines)

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -242,4 +242,5 @@ class UserStoryEvalResponse:
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
             lines.append("\n Reply \"/apply\" to apply these updates.\n")
+            lines.append("\n Reply \"/review\" to re-review this issue.\n")
         return "\n".join(lines)


### PR DESCRIPTION
# What
This PR adds support for the /review flag in GitHub comments. When a user comments /review on an issue, the bot re-evaluates the issue using the AI model and posts a new review comment. This allows users to trigger another AI evaluation without altering the issue content.

- Added support for the /review flag alongside the existing /apply flag.
- Updated handle_github_comment_event to detect /review and call the AI review pipeline without updating the issue.
- Improved comment messaging with clearer instructions:
- Markdown formatting using code blocks (e.g., `/apply`)

### Testing
Tested end-to-end using my forked repository:
### Positive story evaluation
<img width="448" height="712" alt="image" src="https://github.com/user-attachments/assets/a9fd6091-f277-49d0-bd14-1fa979cfcda0" />

### Negative story evaluation
<img width="446" height="415" alt="image" src="https://github.com/user-attachments/assets/495d7529-f31c-4815-a342-9723a4b0d102" />

