### PR TITLE
Add /usage command to display available bot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This action supports the following GitHub workflow events:
   - Used to analyze and enhance new or updated issues.
 - **issue_comment**
   - Triggered on issue comment events such as `created`.
-  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`, `/review`).
+  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`)
 
 Example configuration in your workflow:
 
@@ -141,6 +141,16 @@ on:
 ```
 
 See the [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) for more details on workflow events and triggers.
+
+## Supported Commands
+
+### 🚀 Available Commands
+
+| Command     | Functionality                                                | Notes                                                                 |
+|-------------|--------------------------------------------------------------|-----------------------------------------------------------------------|
+| `/apply`    | Applies the latest AI-enhanced title, body, and labels to the GitHub issue. | Must be used as a GitHub comment on an issue with a valid enhancement suggestion. |
+| `/review`   | Triggers a new AI review of the issue and posts the updated evaluation as a comment. | Does not update the issue directly; useful for iterative refinement or rechecks. |
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See the [GitHub Actions documentation](https://docs.github.com/en/actions/using-
 |-------------|--------------------------------------------------------------|-----------------------------------------------------------------------|
 | `/apply`    | Applies the latest AI-enhanced title, body, and labels to the GitHub issue. | Must be used as a GitHub comment on an issue with a valid enhancement suggestion. |
 | `/review`   | Triggers a new AI review of the issue and posts the updated evaluation as a comment. | Does not update the issue directly; useful for iterative refinement or rechecks. |
+| `/usage`    | Displays a list of available bot commands with descriptions. | Use this to discover what commands the bot supports. |
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This action supports the following GitHub workflow events:
   - Used to analyze and enhance new or updated issues.
 - **issue_comment**
   - Triggered on issue comment events such as `created`.
-  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`).
+  - Used to apply enhancements when a user comments with a specific command (e.g., `/apply`, `/review`).
 
 Example configuration in your workflow:
 

--- a/src/comment_commands.py
+++ b/src/comment_commands.py
@@ -1,5 +1,21 @@
 from enum import Enum
 
-class CommentCommand(Enum):
-    APPLY = "/apply"
+class CommentCommand(str, Enum):
+    APPLY =  "/apply"
     REVIEW = "/review"
+    USAGE =  "/usage"
+
+COMMAND_DESCRIPTIONS = {
+    CommentCommand.APPLY: "Applies the AI-enhanced title, body, and labels to the issue.",
+    CommentCommand.REVIEW: "Re-runs the AI review and posts a fresh evaluation as a comment.",
+    CommentCommand.USAGE: "Displays this list of available commands.",
+}
+
+def get_command_usage_markdown() -> str:
+    lines = [
+        "| Command | Description |",
+        "|---------|-------------|",
+    ]
+    for command, description in COMMAND_DESCRIPTIONS.items():
+        lines.append(f"| `{command.value}` | {description} |")
+    return "\n".join(lines)

--- a/src/comment_commands.py
+++ b/src/comment_commands.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-class CommentCommand(str, Enum):
+class CommentCommand(Enum):
     APPLY =  "/apply"
     REVIEW = "/review"
     USAGE =  "/usage"

--- a/src/comment_commands.py
+++ b/src/comment_commands.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class CommentCommand(str, Enum):
+    APPLY = "/apply"
+    REVIEW = "/review"

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import asyncio
 # Third-party imports
 from github.Issue import Issue
 from semantic_kernel import Kernel
+from comment_commands import CommentCommand
 
 # Local imports
 from github_utils import (
@@ -21,8 +22,6 @@ from prompts import build_user_story_eval_prompt
 from utils import get_env_var
 from response_models import UserStoryEvalResponse
 
-APPLY_COMMENT = "/apply"
-REVIEW_COMMENT = "/review"
 
 def handle_github_issues_event(issue: Issue, kernel: Kernel) -> None:
     """
@@ -56,7 +55,7 @@ def handle_github_comment_event(issue: Issue, issue_comment_id: int) -> None:
     comment = get_github_comment(issue, issue_comment_id)
     comment_body = comment.body.strip().lower()
 
-    if APPLY_COMMENT in comment_body:
+    if CommentCommand.APPLY in comment_body:
         ai_enhanced_comment = get_ai_enhanced_comment(issue)
         if ai_enhanced_comment is None:
             return
@@ -78,7 +77,7 @@ def handle_github_comment_event(issue: Issue, issue_comment_id: int) -> None:
 
         create_github_issue_comment(issue, confirmation_comment)
 
-    elif REVIEW_COMMENT in comment_body:
+    elif CommentCommand.REVIEW in comment_body:
         print(f"Triggering manual review for issue {issue.number}...")
 
         # Initialize the kernel

--- a/src/main.py
+++ b/src/main.py
@@ -4,12 +4,10 @@ import sys
 # Third-party imports
 from github.Issue import Issue
 from semantic_kernel import Kernel
-from comment_commands import CommentCommand
-
 
 # Local imports
 from config import Config
-from comment_commands import CommentCommand
+from comment_commands import (CommentCommand, get_command_usage_markdown)
 from github_utils import (GithubEvent, create_github_issue_comment,
                           get_ai_enhanced_comment, get_github_comment,
                           get_github_issue, update_github_issue)
@@ -80,7 +78,10 @@ async def handle_github_comment_event(
         print(f"Triggering manual review for issue {issue.number}...")
 
         await handle_github_issues_event(issue, kernel)
-
+    elif CommentCommand.USAGE.value in comment_body:
+        usage_md = get_command_usage_markdown()
+        create_github_issue_comment(issue, f"### 🤖 Available Commands\n\n{usage_md}")
+        print(f"Posted usage information for issue {issue.number}.")
     else:
         print(f"Comment {issue_comment_id} does not require processing.")
 

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,8 @@ from prompts import build_user_story_eval_prompt
 from utils import get_env_var
 from response_models import UserStoryEvalResponse
 
-COMMENT_LOOKUP = "/apply"
+APPLY_COMMENT = "/apply"
+REVIEW_COMMENT = "/review"
 
 def handle_github_issues_event(issue: Issue, kernel: Kernel) -> None:
     """
@@ -46,43 +47,54 @@ def handle_github_issues_event(issue: Issue, kernel: Kernel) -> None:
 
 def handle_github_comment_event(issue: Issue, issue_comment_id: int) -> None:
     """
-    Apply AI-suggested enhancements to a GitHub issue if requested in a comment.
+    Apply AI-suggested enhancements to a GitHub issue, or trigger a re-review if requested in a comment.
 
     Args:
         issue (Issue): The GitHub issue to update.
-        issue_comment_id (int): The ID of the comment triggering the enhancement.
+        issue_comment_id (int): The ID of the comment triggering the enhancement or review.
     """
     comment = get_github_comment(issue, issue_comment_id)
+    comment_body = comment.body.strip().lower()
 
-    if COMMENT_LOOKUP not in comment.body:
+    if APPLY_COMMENT in comment_body:
+        ai_enhanced_comment = get_ai_enhanced_comment(issue)
+        if ai_enhanced_comment is None:
+            return
+
+        user_story_eval = UserStoryEvalResponse.from_markdown(ai_enhanced_comment)
+
+        update_github_issue(
+            issue,
+            title=user_story_eval.refactored.title,
+            body=user_story_eval.refactored.body_markdown(),
+            labels=user_story_eval.labels,
+        )
+
+        quoted_body = "\n".join([f"> {line}" for line in user_story_eval.to_markdown().strip().splitlines()])
+        confirmation_comment = (
+            f"✅ Applied enhancements based on the following comment:\n\n"
+            f"{quoted_body}"
+        )
+
+        create_github_issue_comment(issue, confirmation_comment)
+
+    elif REVIEW_COMMENT in comment_body:
+        print(f"Triggering manual review for issue {issue.number}...")
+
+        # Initialize the kernel
+        azure_openai_target_uri = get_env_var("INPUT_AZURE_OPENAI_TARGET_URI")
+        azure_openai_api_key = get_env_var("INPUT_AZURE_OPENAI_API_KEY")
+
+        kernel = initialize_kernel(
+            azure_openai_target_uri=azure_openai_target_uri,
+            azure_openai_api_key=azure_openai_api_key,
+        )
+
+        handle_github_issues_event(issue, kernel)
+
+    else:
         print(f"Comment {issue_comment_id} does not require processing.")
-        return
 
-    ai_enhanced_comment = get_ai_enhanced_comment(issue)
-
-    if ai_enhanced_comment is None:
-        return
-
-    user_story_eval = UserStoryEvalResponse.from_markdown(ai_enhanced_comment)
-
-    update_github_issue(
-        issue,
-        title=user_story_eval.refactored.title,
-        body=user_story_eval.refactored.body_markdown(),
-        labels=user_story_eval.labels,
-    )
-
-    quoted_body = "\n".join([f"> {line}" for line in user_story_eval.to_markdown().strip().splitlines()])
-
-    # Confirmation comment quoting the original enhancement comment
-    confirmation_comment = (
-        f"✅ Applied enhancements based on the following comment:\n\n"
-        f"{quoted_body}"
-    )
-
-    create_github_issue_comment(
-        issue, confirmation_comment
-    )
 
 
 def main() -> None:

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -241,6 +241,6 @@ class UserStoryEvalResponse:
         if self.refactored and (not self.ready_to_work and not self.base_story_not_clear):
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
-            lines.append('\n Reply with "/apply" to apply these updates, or "/review" to trigger another review of the story.\n')
+            lines.append('\n Reply with `/apply` to accept these changes, or `/review` to run another evaluation.\n')
 
         return "\n".join(lines)

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -241,6 +241,8 @@ class UserStoryEvalResponse:
         if self.refactored and (not self.ready_to_work and not self.base_story_not_clear):
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
-            lines.append('\n Reply with `/apply` to accept these changes, or `/review` to run another evaluation.\n')
+            lines.append("\n Reply `/apply` to apply these changes.\n")
+            
+        lines.append("\n Reply `/review` to run another evaluation.\n")
 
         return "\n".join(lines)

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -241,6 +241,6 @@ class UserStoryEvalResponse:
         if self.refactored and (not self.ready_to_work and not self.base_story_not_clear):
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
-            lines.append("\n Reply \"/apply\" to apply these updates.\n")
-            lines.append("\n Reply \"/review\" to re-review this issue.\n")
+            lines.append('\n Reply with "/apply" to apply these updates, or "/review" to trigger another review of the story.\n')
+
         return "\n".join(lines)

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -242,4 +242,5 @@ class UserStoryEvalResponse:
             lines.append("\n### Refactored Story")
             lines.append(self.refactored.to_markdown())
             lines.append("\n Reply \"/apply\" to apply these updates.\n")
+            lines.append("\n Reply \"/review\" to re-review this issue.\n")
         return "\n".join(lines)

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -244,5 +244,6 @@ class UserStoryEvalResponse:
             lines.append("\n Reply `/apply` to apply these changes.\n")
             
         lines.append("\n Reply `/review` to run another evaluation.\n")
+        lines.append("\n Reply `/usage` to see available commands.\n")
 
         return "\n".join(lines)


### PR DESCRIPTION
### What

- Introduced a new /usage command to the CommentCommand enum to make the repo agent more chatbot like.
- Updated the comment handler to respond to /usage by posting a Markdown table listing all supported commands and their descriptions.

### Testing

- Manually tested on forked repository by posting /usage as a comment on an issue.
- Verified that the bot replied with a correctly formatted Markdown table including /apply, /review, and /usage.

<img width="446" height="300" alt="{4D4B1416-4341-4B4A-BDAE-35E7C8B5F5D8}" src="https://github.com/user-attachments/assets/03abc24a-eba1-459d-8f89-6575b42c109d" />
